### PR TITLE
use isSpecialLayer and isMasterLayer

### DIFF
--- a/Layers/Delete all non-Master layers.py
+++ b/Layers/Delete all non-Master layers.py
@@ -10,42 +10,18 @@ from __future__ import (
 __doc__ = """
 Goes through selected glyphs and deletes all glyph layers which are not a Master, Bracket or Brace layer.
 """
-
-
 Font = Glyphs.font
 selectedLayers = Font.selectedLayers
-searchTerms = ["[]", "{}"]
-
 
 def process(thisGlyph):
     count = 0
-
     numberOfLayers = len(thisGlyph.layers)
     for i in range(numberOfLayers)[::-1]:
         thisLayer = thisGlyph.layers[i]
-        if (
-            thisLayer.layerId != thisLayer.associatedMasterId
-        ):  # not the master layer
-            thisLayerName = thisLayer.name
-            thisLayerShouldBeRemoved = True
-            if thisLayerName:  # always delete unnamed layers
-                for parentheses in searchTerms:
-                    opening = parentheses[0]
-                    closing = parentheses[1]
-
-                    # check if ONE of them is at the END of the layer name, like:
-                    # Bold [160], Bold [160[, Bold ]160], Regular {120}
-                    if thisLayerName.endswith(
-                        opening
-                    ) or thisLayerName.endswith(closing):
-                        thisLayerShouldBeRemoved = False
-
-            if thisLayerShouldBeRemoved:
-                count += 1
-                del thisGlyph.layers[i]
-
+        if not thisLayer.isSpecialLayer and not thisLayer.isMasterLayer:
+            count += 1
+            del thisGlyph.layers[i]
     return count
-
 
 Font.disableUpdateInterface()
 


### PR DESCRIPTION
Hi @jenskutilek! Glyphs has changed the way special layers work internally; you can now have layers with names like `{140, 72}` but they need to be explicitly set as brace or bracket layers in order to function that way. Glyphs now provides a couple of helper methods — `isSpecialLayer` and `isMasterLayer` — to `GSLayer`, so I re-implemented the script to use them.

Thanks as always for sharing all your great scripts with the community 😄 
